### PR TITLE
Feat: update readme so users use the package manager instead of the installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # VIVE OpenXR Plugin
 The "VIVE OpenXR Plugin" plugin package contains some OpenXR Unity features for developers to use.
 ## How to install:
-### 1. Download the unitypackage from the github.
-https://github.com/ViveSoftware/VIVE-OpenXR/blob/master/Installer/ViveOpenXRInstaller.unitypackage
-### 2. Import the unitypackage file in the Unity editor.
-### 3. Select the menu on the Unity UI "VIVE/OpenXR Installer", press "Install or Update latest version".
+### 1. Download & install Git on your computer 
+[https://git-scm.com/](https://git-scm.com/)
+### 2. If you are on windows, restart your computer so Git path is correctly setup in your environment variables
+### 3. Open Unity
+### 4. Open the Package Manager
+### 5. Select [+] 
+### 6. Select "Add from Git URL"
+### 7. Paste this URL
+https://github.com/ViveSoftware/VIVE-OpenXR.git?path=com.htc.upm.vive.openxr
+### 8. Confirm
 
 Note: For "Install specific version", please copy the release version from https://github.com/ViveSoftware/VIVE-OpenXR/releases,
 then paste the version(for example: "1.0.12") to install the specific version.


### PR DESCRIPTION
I changed the installation process because the Installer is not really useful.
Beside, we do not need to maintain the installer.
Using the package manager is the best way for downloading packages