### PR TITLE
Fix compile errors when not using UNITY_STANDALONE or ANDROID platforms

### DIFF
--- a/com.htc.upm.vive.openxr/Runtime/CompositionLayer/Scripts/CompositionLayerPassthroughAPI.cs
+++ b/com.htc.upm.vive.openxr/Runtime/CompositionLayer/Scripts/CompositionLayerPassthroughAPI.cs
@@ -416,6 +416,7 @@ namespace VIVE.OpenXR.CompositionLayer.Passthrough
 #if UNITY_ANDROID
 			return passthroughFeature.HTCPassthrough_DestroyPassthrough(passthroughID);
 #endif
+            return false;
 		}
 
 		/// <summary>
@@ -474,7 +475,8 @@ namespace VIVE.OpenXR.CompositionLayer.Passthrough
 			else
 				return false;
 #endif
-		}
+            return false;
+        }
 
 		/// <summary>
 		/// For modifying the mesh data of a projected passthrough layer.
@@ -545,6 +547,7 @@ namespace VIVE.OpenXR.CompositionLayer.Passthrough
 #if UNITY_ANDROID
 			return passthroughFeature.HTCPassthrough_SetMesh(passthroughID, (uint)vertexBuffer.Length, vertexBufferXrVector, (uint)indexBuffer.Length, indexBufferUint); ;
 #endif
+            return false;
 		}
 
 		/// <summary>
@@ -623,7 +626,8 @@ namespace VIVE.OpenXR.CompositionLayer.Passthrough
 #if UNITY_ANDROID
 			return passthroughFeature.HTCPassthrough_SetMeshTransform(passthroughID, passthroughFeature.GetXrSpaceFromSpaceType(spaceType), meshXrPose, meshXrScale);
 #endif
-		}
+            return false;
+        }
 
 		/// <summary>
 		/// For modifying layer type and composition depth of a passthrough layer.
@@ -661,7 +665,7 @@ namespace VIVE.OpenXR.CompositionLayer.Passthrough
 #if UNITY_ANDROID
 			return passthroughFeature.HTCPassthrough_SetLayerType(passthroughID, layerType, compositionDepth);
 #endif
-
+            return false;
 		}
 
 		/// <summary>
@@ -702,6 +706,7 @@ namespace VIVE.OpenXR.CompositionLayer.Passthrough
 #if UNITY_ANDROID
 			return passthroughFeature.HTCPassthrough_SetMeshTransformSpace(passthroughID, passthroughFeature.GetXrSpaceFromSpaceType(spaceType));
 #endif
+            return false;
 		}
 
 		/// <summary>
@@ -764,6 +769,7 @@ namespace VIVE.OpenXR.CompositionLayer.Passthrough
 #if UNITY_ANDROID
 			return passthroughFeature.HTCPassthrough_SetMeshTransformPosition(passthroughID, OpenXRHelper.ToOpenXRVector(trackingSpaceMeshPosition, convertFromUnityToOpenXR));
 #endif
+            return false;
 		}
 
 		/// <summary>
@@ -826,6 +832,7 @@ namespace VIVE.OpenXR.CompositionLayer.Passthrough
 #if UNITY_ANDROID
 			return passthroughFeature.HTCPassthrough_SetMeshTransformOrientation(passthroughID, OpenXRHelper.ToOpenXRQuaternion(trackingSpaceMeshRotation, convertFromUnityToOpenXR));
 #endif
+            return false;
 		}
 
 		/// <summary>
@@ -867,6 +874,7 @@ namespace VIVE.OpenXR.CompositionLayer.Passthrough
 #if UNITY_ANDROID
 			return passthroughFeature.HTCPassthrough_SetMeshTransformScale(passthroughID, OpenXRHelper.ToOpenXRVector(meshScale, false));
 #endif
+            return false;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Fixes https://github.com/ViveSoftware/VIVE-OpenXR-Unity/issues/5

Fixes the following compliation errors when unity is set to a platform which is not Standalone or Android.

```
Library\PackageCache\com.htc.upm.vive.openxr@df2fc918e700\Runtime\CompositionLayer\Scripts\CompositionLayerPassthroughAPI.cs(390,22): error CS0161: 'CompositionLayerPassthroughAPI.DestroyPassthrough(int)': not all code paths return a value

Library\PackageCache\com.htc.upm.vive.openxr@df2fc918e700\Runtime\CompositionLayer\Scripts\CompositionLayerPassthroughAPI.cs(442,22): error CS0161: 'CompositionLayerPassthroughAPI.SetPassthroughAlpha(int, float, bool)': not all code paths return a value

Library\PackageCache\com.htc.upm.vive.openxr@df2fc918e700\Runtime\CompositionLayer\Scripts\CompositionLayerPassthroughAPI.cs(498,22): error CS0161: 'CompositionLayerPassthroughAPI.SetProjectedPassthroughMesh(int, Vector3[], int[], bool)': not all code paths return a value

Library\PackageCache\com.htc.upm.vive.openxr@df2fc918e700\Runtime\CompositionLayer\Scripts\CompositionLayerPassthroughAPI.cs(578,22): error CS0161: 'CompositionLayerPassthroughAPI.SetProjectedPassthroughMeshTransform(int, ProjectedPassthroughSpaceType, Vector3, Quaternion, Vector3, bool, bool)': not all code paths return a value

Library\PackageCache\com.htc.upm.vive.openxr@df2fc918e700\Runtime\CompositionLayer\Scripts\CompositionLayerPassthroughAPI.cs(644,22): error CS0161: 'CompositionLayerPassthroughAPI.SetPassthroughLayerType(int, LayerType, uint)': not all code paths return a value

Library\PackageCache\com.htc.upm.vive.openxr@df2fc918e700\Runtime\CompositionLayer\Scripts\CompositionLayerPassthroughAPI.cs(679,22): error CS0161: 'CompositionLayerPassthroughAPI.SetProjectedPassthroughSpaceType(int, ProjectedPassthroughSpaceType)': not all code paths return a value

Library\PackageCache\com.htc.upm.vive.openxr@df2fc918e700\Runtime\CompositionLayer\Scripts\CompositionLayerPassthroughAPI.cs(726,22): error CS0161: 'CompositionLayerPassthroughAPI.SetProjectedPassthroughMeshPosition(int, Vector3, bool, bool)': not all code paths return a value

Library\PackageCache\com.htc.upm.vive.openxr@df2fc918e700\Runtime\CompositionLayer\Scripts\CompositionLayerPassthroughAPI.cs(788,22): error CS0161: 'CompositionLayerPassthroughAPI.SetProjectedPassthroughMeshOrientation(int, Quaternion, bool, bool)': not all code paths return a value

Library\PackageCache\com.htc.upm.vive.openxr@df2fc918e700\Runtime\CompositionLayer\Scripts\CompositionLayerPassthroughAPI.cs(843,22): error CS0161: 'CompositionLayerPassthroughAPI.SetProjectedPassthroughScale(int, Vector3)': not all code paths return a value
```