### PR TITLE
Add fallback return false for passthrough methods

### DIFF
--- a/com.htc.upm.vive.openxr/Runtime/CompositionLayer/Scripts/CompositionLayerPassthroughAPI.cs
+++ b/com.htc.upm.vive.openxr/Runtime/CompositionLayer/Scripts/CompositionLayerPassthroughAPI.cs
@@ -416,6 +416,7 @@ namespace VIVE.OpenXR.CompositionLayer.Passthrough
 #if UNITY_ANDROID
 			return passthroughFeature.HTCPassthrough_DestroyPassthrough(passthroughID);
 #endif
+			return false;
 		}
 
 		/// <summary>
@@ -474,6 +475,7 @@ namespace VIVE.OpenXR.CompositionLayer.Passthrough
 			else
 				return false;
 #endif
+			return false;
 		}
 
 		/// <summary>
@@ -545,6 +547,7 @@ namespace VIVE.OpenXR.CompositionLayer.Passthrough
 #if UNITY_ANDROID
 			return passthroughFeature.HTCPassthrough_SetMesh(passthroughID, (uint)vertexBuffer.Length, vertexBufferXrVector, (uint)indexBuffer.Length, indexBufferUint); ;
 #endif
+			return false;
 		}
 
 		/// <summary>
@@ -623,6 +626,7 @@ namespace VIVE.OpenXR.CompositionLayer.Passthrough
 #if UNITY_ANDROID
 			return passthroughFeature.HTCPassthrough_SetMeshTransform(passthroughID, passthroughFeature.GetXrSpaceFromSpaceType(spaceType), meshXrPose, meshXrScale);
 #endif
+			return false;
 		}
 
 		/// <summary>
@@ -661,7 +665,7 @@ namespace VIVE.OpenXR.CompositionLayer.Passthrough
 #if UNITY_ANDROID
 			return passthroughFeature.HTCPassthrough_SetLayerType(passthroughID, layerType, compositionDepth);
 #endif
-
+			return false;
 		}
 
 		/// <summary>
@@ -702,6 +706,7 @@ namespace VIVE.OpenXR.CompositionLayer.Passthrough
 #if UNITY_ANDROID
 			return passthroughFeature.HTCPassthrough_SetMeshTransformSpace(passthroughID, passthroughFeature.GetXrSpaceFromSpaceType(spaceType));
 #endif
+			return false;
 		}
 
 		/// <summary>
@@ -764,6 +769,7 @@ namespace VIVE.OpenXR.CompositionLayer.Passthrough
 #if UNITY_ANDROID
 			return passthroughFeature.HTCPassthrough_SetMeshTransformPosition(passthroughID, OpenXRHelper.ToOpenXRVector(trackingSpaceMeshPosition, convertFromUnityToOpenXR));
 #endif
+			return false;
 		}
 
 		/// <summary>
@@ -826,6 +832,7 @@ namespace VIVE.OpenXR.CompositionLayer.Passthrough
 #if UNITY_ANDROID
 			return passthroughFeature.HTCPassthrough_SetMeshTransformOrientation(passthroughID, OpenXRHelper.ToOpenXRQuaternion(trackingSpaceMeshRotation, convertFromUnityToOpenXR));
 #endif
+			return false;
 		}
 
 		/// <summary>
@@ -867,6 +874,7 @@ namespace VIVE.OpenXR.CompositionLayer.Passthrough
 #if UNITY_ANDROID
 			return passthroughFeature.HTCPassthrough_SetMeshTransformScale(passthroughID, OpenXRHelper.ToOpenXRVector(meshScale, false));
 #endif
+			return false;
 		}
 
 		/// <summary>


### PR DESCRIPTION
This patch adds a missing fallback return false; to the passthrough methods. A function must always guarantee a return value that matches its signature, even when the code path seems obvious. Without that, the compiler complains.

This change ensures the method now consistently returns a valid boolean in all cases. (A small reminder that one of the most fundamental rules in programming is: if a function says it returns something… it should actually return something 😉)